### PR TITLE
Let exceptions escape to the caller if desired

### DIFF
--- a/confluence/confluence.py
+++ b/confluence/confluence.py
@@ -199,7 +199,7 @@ class Confluence(object):
             page = self._server.confluence1.getPage(self._token, space, page)
         return page
 
-    def attachFile(self, page, space, files):
+    def attachFile(self, page, space, files, propogate = False):
         if self._token2:
             server = self._server.confluence2
             token = self._token2
@@ -230,6 +230,8 @@ class Confluence(object):
                 logging.info("done")
             except xmlrpclib.Error:
                 logging.exception("Unable to attach %s", filename)
+                if propogate :
+                    raise
             finally:
                 f.close()
 


### PR DESCRIPTION
Currently, if a file ails to attach the user of the API gets no
programatic way of dealing with this situation. The API wrapper catches
the xmlrpc fault, logs the error, then does nothing.

Given the funiton as written has no return code semantics it seems
easier to have the exception escape back to the caller if a parameter is
set rather then change the way the function should be interacted with
