### PR TITLE
os.path.split does not work if a file is specified with a path

### DIFF
--- a/confluence/confluence.py
+++ b/confluence/confluence.py
@@ -219,7 +219,7 @@ class Confluence(object):
                 "jpeg": "image/jpeg",
                 "pdf": "application/pdf",
             }
-            extension = os.path.split(filename)[1]
+            extension = os.path.splitext(filename)[1:]
             ty = content_types.get(extension, "application/binary")
             attachment = {"fileName": filename, "contentType": ty, "comment": files[filename]}
             f = open(filename, "rb")


### PR DESCRIPTION
e.g.

some_file.png works fine but
/path/to/some_file.png

just breaks with os.path.slit whilst os.path.splitext works as
indended
