### PR TITLE
Confluence() parameters should be ConfigParser defaults

### DIFF
--- a/confluence/confluence.py
+++ b/confluence/confluence.py
@@ -106,7 +106,7 @@ class Confluence(object):
         "verify": True
     }
 
-    def __init__(self, profile=None, url="http://localhost:8090/", username=None, password=None, appid=None):
+    def __init__(self, profile=None, url="http://localhost:8090/", username=None, password=None, appid=None, debug=False):
         """
         Returns a Confluence object by loading the connection details from the `config.ini` file.
 
@@ -155,10 +155,11 @@ class Confluence(object):
                 if os.path.isfile(possible):
                     return possible
             return None
-        config = ConfigParser.SafeConfigParser(defaults={'user': None, 'pass': None, 'appid': appid})
+
+        config = ConfigParser.SafeConfigParser(defaults={'user': username, 'pass': password, 'appid': appid})
 
         config_file = findfile('config.ini')
-        print(config_file)
+        if debug: print(config_file)
 
         if not profile:
             if config_file:


### PR DESCRIPTION
This change initializes the ConfigParser in Confluence() to use as
defaults any parameters passed to __init__.  Parameters in the config
file still take precedence, but if username, password, or appid are
missing from the config file but they are passed to Confluence() the
values passed in will be used.

Added whitespace after findfile and before config = because I believe it
is in keeping with PEP8 to have the class methods set out by blank
lines.

Added debug to the named parameters to init so that the
print(config_file) line can be optionally invoked.  I believe that is a
debugging tool and not intended (or wanted) in the final.