### PR TITLE
Update URL for test.pypi.org to avoid redirects breaking CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ deploy:
     condition: $TOXENV != docs
     branch: master
 - provider: pypi
-  server: https://test.pypi.org/legacy
+  server: https://test.pypi.org/legacy/
   user: sorins
   password:
     secure: E0cjANF7SLBdYrsnWLK8X/xWznqkF0JrP/DVfDazPzUYH6ynFeneyofzNJQPLTLsqe1eKXhuUJ/Sbl+RHFB0ySo/j/7NfYd/9pm8hpUkGCvR09IwtvMLgWKp3k10NWab03o2GOkSJSrLvZofyZBGR40wwu2O9uXPCb2rvucCGbw=


### PR DESCRIPTION
Trailing '/' is apparently important, according to
https://github.com/pypa/python-packaging-user-guide/pull/361